### PR TITLE
RV64Iに対応

### DIFF
--- a/HDL_SIM/CORE/MemoryAccess/Makefile
+++ b/HDL_SIM/CORE/MemoryAccess/Makefile
@@ -3,7 +3,7 @@
 # File Created: 2018/11/25 06:07
 # Author: Masaru Aoki ( masaru.aoki.1972@gmail.com )
 ######
-# Last Modified: 2019/01/06 05:28
+# Last Modified: 2019/01/24 04:54
 # Modified By: Masaru Aoki ( masaru.aoki.1972@gmail.com )
 ######
 # Copyright 2018 - 2018  Project RockWave
@@ -18,7 +18,10 @@
 # testbench = memoryaccess_tb
 # testmodule = ../../../HDL_SRC/CORE/MemoryAccess/top_memoryaccess.v
 
-testbench = top_memoryaccess_tb
+# testbench = top_memoryaccess_tb
+# testmodule = ../../../HDL_SRC/CORE/MemoryAccess/top_memoryaccess.v ../../../HDL_SRC/CORE/MemoryAccess/ram.v
+
+testbench = top_memoryaccess_rv64i_tb
 testmodule = ../../../HDL_SRC/CORE/MemoryAccess/top_memoryaccess.v ../../../HDL_SRC/CORE/MemoryAccess/ram.v
 
 INCDIR = ../../../HDL_SRC/CORE/

--- a/HDL_SIM/CORE/MemoryAccess/top_memoryaccess_rv64i_tb.v
+++ b/HDL_SIM/CORE/MemoryAccess/top_memoryaccess_rv64i_tb.v
@@ -1,17 +1,18 @@
 /*
  * *****************************************************************
- * File: top_memoryaccess_tb.v
+ * File: top_memoryaccess_rv64i_tb.v
  * Category: MemoryAccess
  * File Created: 2019/01/06 04:28
  * Author: Masaru Aoki ( masaru.aoki.1972@gmail.com )
  * *****
- * Last Modified: 2019/01/24 04:46
+ * Last Modified: 2019/01/24 05:00
  * Modified By: Masaru Aoki ( masaru.aoki.1972@gmail.com )
  * *****
  * Copyright 2018 - 2019  Project RockWave
  * *****************************************************************
  * Description:
  *   top_memoryaccessとramを組み合わせたテスト
+ *       RV64I Ver.
  * *****************************************************************
  * HISTORY:
  * Date      	By        	Comments
@@ -23,7 +24,9 @@
  `define STEP 5
  `timescale 1ns/1ns
 
-module top_memoryaccess_tb;
+ `define RV64I
+
+module top_memoryaccess_rv64i_tb;
     `include "core_general.vh"
 
     reg clk;                       // Global Clock
@@ -101,7 +104,7 @@ end
 // Test Bench
 initial begin
     $dumpfile("top_memoryaccess.vcd");
-    $dumpvars(0,top_memoryaccess_tb);
+    $dumpvars(0,top_memoryaccess_rv64i_tb);
 
     rst_n=0;
     decoded_op_em=0;
@@ -124,39 +127,53 @@ initial begin
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_B;
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
     alu_out_em = 32'h0000_0000;  // addr
-    rs2data_em = 32'h5555_5555;  // data
+    rs2data_em = 64'h5555_5555_5555_5555;  // data
     @( posedge phase_execute )
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'h0000_0055);
+    assert_eq(mem_out_mw,64'h0000_0000_0000_0055);
 
     $display("sh :STORE Halfword");
     @( posedge phase_execute )
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_H;
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
     alu_out_em = 32'h0000_0004;  // addr
-    rs2data_em = 32'hAAAA_AAAA;  // data
+    rs2data_em = 64'hAAAA_AAAA_AAAA_AAAA;  // data
     @( posedge phase_execute )
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'h0000_AAAA);
+    assert_eq(mem_out_mw,64'h0000_0000_0000_AAAA);
 
     $display("sw :STORE Word");
     @( posedge phase_execute )
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
     alu_out_em = 32'h0000_0008;  // addr
-    rs2data_em = 32'hFFFF_FFFF;  // data
+    rs2data_em = 64'hFFFF_FFFF_FFFF_FFFF;  // data
     @( posedge phase_execute )
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
-    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'hFFFF_FFFF);
+    assert_eq(mem_out_mw,64'h0000_0000_FFFF_FFFF);
+
+    // RV64I
+    $display("sd :STORE Double");
+    @( posedge phase_execute )
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
+    decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
+    alu_out_em = 32'h0000_0008;  // addr
+    rs2data_em = 64'hFFFF_FFFF_FFFF_FFFF;  // data
+    @( posedge phase_execute )
+    decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
+    @( posedge phase_memoryaccess )
+    #(1)
+    assert_eq(mem_out_mw,64'hFFFF_FFFF_FFFF_FFFF);
 
     ////////////////////////////////////////
     // LOAD系動作確認
@@ -166,58 +183,79 @@ initial begin
     /////
     $display("lb :Load Byte");
     @( posedge phase_execute )
-    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
     alu_out_em = 32'h0000_000C;  // addr
-    rs2data_em = 32'hFFFF_FFFF;  // data
+    rs2data_em = 64'hFFFF_FFFF_FFFF_FFFF;  // data
     @( posedge phase_execute )
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_B;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'hFFFF_FFFF);
+    assert_eq(mem_out_mw,64'hFFFF_FFFF_FFFF_FFFF);
     /////
     $display("lbu:Load Byte Unsinged");
     @( posedge phase_execute )
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_BU;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'h0000_00FF);
+    assert_eq(mem_out_mw,64'h0000_0000_0000_00FF);
 
     /////
     $display("lh :Load Halfword");
     @( posedge phase_execute )
-    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
     alu_out_em = 32'h0000_0010;  // addr
-    rs2data_em = 32'hAAAA_AAAA;  // data
+    rs2data_em = 64'hAAAA_AAAA_AAAA_AAAA;  // data
     @( posedge phase_execute )
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_H;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'hFFFF_AAAA);
+    assert_eq(mem_out_mw,64'hFFFF_FFFF_FFFF_AAAA);
     /////
     $display("lhu:Load Halfword Unsinged");
     @( posedge phase_execute )
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_HU;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'h0000_AAAA);
+    assert_eq(mem_out_mw,64'h0000_0000_0000_AAAA);
 
     /////
     $display("lw :Load Word");
     @( posedge phase_execute )
-    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
     alu_out_em = 32'h0000_0014;  // addr
-    rs2data_em = 32'h5555_5555;  // data
+    rs2data_em = 64'hEFEF_EFEF_EFEF_EFEF;  // data
     @( posedge phase_execute )
     decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
     decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_W;
     @( posedge phase_memoryaccess )
     #(1)
-    assert_eq(mem_out_mw,32'h5555_5555);
+    assert_eq(mem_out_mw,64'hFFFF_FFFF_EFEF_EFEF);
+    ///// RV64I
+    $display("lhu:Load Word Unsinged");
+    @( posedge phase_execute )
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_WU;
+    @( posedge phase_memoryaccess )
+    #(1)
+    assert_eq(mem_out_mw,64'h0000_0000_EFEF_EFEF);
+
+    ///// RV64I
+    $display("lw :Load Double");
+    @( posedge phase_execute )
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
+    decoded_op_em[DATA_MEM_WE_BIT] = 1'b1;
+    alu_out_em = 32'h0000_0014;  // addr
+    rs2data_em = 64'h0000_5555_AAAA_FFFF;  // data
+    @( posedge phase_execute )
+    decoded_op_em[DATA_MEM_WE_BIT] = 1'b0;
+    decoded_op_em[FUNCT3_BIT_M:FUNCT3_BIT_L] = FUNCT3_D;
+    @( posedge phase_memoryaccess )
+    #(1)
+    assert_eq(mem_out_mw,64'h0000_5555_AAAA_FFFF);
 
     $display("All test is GREEN");
     $finish;

--- a/HDL_SRC/CORE/MemoryAccess/ram.v
+++ b/HDL_SRC/CORE/MemoryAccess/ram.v
@@ -5,7 +5,7 @@
  * File Created: 2018/12/30 06:13
  * Author: Masaru Aoki ( masaru.aoki.1972@gmail.com )
  * *****
- * Last Modified: 2019/01/06 05:23
+ * Last Modified: 2019/01/24 04:37
  * Modified By: Masaru Aoki ( masaru.aoki.1972@gmail.com )
  * *****
  * Copyright 2018 - 2018  Project RockWave
@@ -17,6 +17,7 @@
  * HISTORY:
  * Date      	By        	Comments
  * ----------	----------	----------------------------------------
+ * 2019/01/24	Masaru Aoki	RV64Iに対応
  * 2019/01/04	Masaru Aoki	Byte / HalfWord / Wordアクセスに対応
  * 2018/12/30	Masaru Aoki	First Version
  * *****************************************************************
@@ -44,7 +45,21 @@ module ram(
     integer i;
     initial for (i=0; i<WORDS+3; i=i+1) mem[i] = 0;
     always @(posedge clk) begin
+`ifdef RV64I
+        if(we == 3'b1_11) begin // Double
+            mem[addr  ] <= qin[ 7: 0];
+            mem[addr+1] <= qin[15: 8];
+            mem[addr+2] <= qin[23:16];
+            mem[addr+3] <= qin[31:24];
+            mem[addr+4] <= qin[39:32];
+            mem[addr+5] <= qin[47:40];
+            mem[addr+6] <= qin[55:48];
+            mem[addr+7] <= qin[63:56];
+        end
+        else if(we == 3'b1_10) begin // Word
+`else
         if(we == 3'b1_10) begin // Word
+`endif
             mem[addr  ] <= qin[ 7: 0];
             mem[addr+1] <= qin[15: 8];
             mem[addr+2] <= qin[23:16];
@@ -64,7 +79,11 @@ module ram(
             qout <= {DWIDTH{1'b0}};
         end
         else begin
-            qout <= {mem[addr+3],mem[addr+2],mem[addr+1],mem[addr]};
+            qout <= {
+`ifdef RV64I
+                    mem[addr+7],mem[addr+6],mem[addr+5],mem[addr+4],
+`endif
+                    mem[addr+3],mem[addr+2],mem[addr+1],mem[addr  ]};
         end
     end
 endmodule

--- a/HDL_SRC/CORE/core_general.vh
+++ b/HDL_SRC/CORE/core_general.vh
@@ -5,8 +5,8 @@
  * File Created: 2018/12/18 04:23
  * Author: Masaru Aoki ( masaru.aoki.1972@gmail.com )
  * *****
- * Last Modified: 2019/01/09 18:25
- * Modified By: kidtak51 ( 45393331+kidtak51@users.noreply.github.com )
+ * Last Modified: 2019/01/24 04:29
+ * Modified By: Masaru Aoki ( masaru.aoki.1972@gmail.com )
  * *****
  * Copyright 2018 - 2018  Project RockWave
  * *****************************************************************
@@ -16,6 +16,7 @@
  * HISTORY:
  * Date      	By        	Comments
  * ----------	----------	----------------------------------------
+ * 2019/01/24	Masaru Aoki	64bitの記述を追加
  * 2019/01/09	kidtak51	  各制御ブロックの出力段のFlipFlopを除去するための定義を追加した
  * 2019/1/4	  kidtak51	  parameter名一部修正
  * 2018/12/28	Masaru Aoki	FUNCT3 / DataMemWE / JumpEn 追加
@@ -23,8 +24,14 @@
  * *****************************************************************
  */
 
+//    `define RV64I
+
     // CPU Register Bit Size
-    parameter XLEN = 32;
+  `ifdef RV64I
+      parameter XLEN = 64;
+  `else
+      parameter XLEN = 32;
+  `endif
     
     /////////////////////////////////////////////
     // Instruction Memory
@@ -66,8 +73,10 @@
       parameter FUNCT3_B = 3'b000;
       parameter FUNCT3_H = 3'b001;
       parameter FUNCT3_W = 3'b010;
+      parameter FUNCT3_D = 3'b011;      // RV64
       parameter FUNCT3_BU = 3'b100;
       parameter FUNCT3_HU = 3'b101;
+      parameter FUNCT3_WU = 3'b110;     // RV64
       // BRANCH
       parameter FUNCT3_BEQ  = 3'b000;
       parameter FUNCT3_BNE  = 3'b001;


### PR DESCRIPTION
RV64Iで追加される命令 (LWU/LD/SD)に対応した
コンパイラ指定子が必要となるため、`define RV64Iで切り替える
RV64Iの有無でXLENを変更する